### PR TITLE
Updating extractEnv and associated internal functions

### DIFF
--- a/R/build_urls.R
+++ b/R/build_urls.R
@@ -300,9 +300,9 @@
       url_df %>%
       mutate(valid = sapply(url_name, valid_url))
     
-    if(verbose){
-      message('Data for the following dates are not available on IMOS:\n', paste(as.Date(url_tab[url_tab$valid %in% FALSE, "date"]), sep = "\n"))
-    }
+    # if(verbose){
+    #   message('Data for the following dates are not available on IMOS:\n', paste(as.Date(url_tab[url_tab$valid %in% FALSE, "date"]), sep = "\n"))
+    # }
     
     url_df <- filter(url_tab, valid %in% TRUE)
     

--- a/R/pull_var.R
+++ b/R/pull_var.R
@@ -40,7 +40,7 @@
            .cache,
            .crop,
            .nrt = FALSE,
-           .output_format = "raster",
+           .output_format = ".grd",
            .parallel = TRUE,
            .ncores = NULL,
            verbose = TRUE) {
@@ -132,7 +132,7 @@
           ras <- ras - 273.15
         }
         
-        return(wrap(ras))
+        return(terra::wrap(ras))
       }
       
       ras.lst <- split(urls, urls$date) %>%
@@ -141,7 +141,7 @@
                    .progress = TRUE)
       
       ## unpack SpatRasters now that they've passed through the connection
-      ras.lst <- lapply(ras.lst, unwrap)
+      ras.lst <- lapply(ras.lst, terra::unwrap)
       
       if (.crop) {
         ras.lst <- lapply(ras.lst, crop, y = study_extent)
@@ -157,7 +157,7 @@
       ## run through urls to download, crop and stack environmental variables
       
       ## establish a log to store all erroneous urls
-#      error_log <- tibble(date = as.Date(NULL), url_name = NULL, layer = NULL)
+      # error_log <- tibble(date = as.Date(NULL), url_name = NULL, layer = NULL)
       pb <- txtProgressBar(max = nrow(urls), style = 3)
       
       ras_lst <- lapply(1:nrow(urls), function(i) {
@@ -256,9 +256,9 @@
                        subds = "UCUR")
           
           return(list(
-            gsla = wrap(gsla),
-            vcur = wrap(vcur),
-            ucur = wrap(ucur)
+            gsla = terra::wrap(gsla),
+            vcur = terra::wrap(vcur),
+            ucur = terra::wrap(ucur)
           ))
           
         }
@@ -368,14 +368,14 @@
     
     ## Save as requested raster output format
     if(var_name %in% "rs_current"){
-      writeRaster(out_brick$gsla, filename = paste0(file.path(path, "rs_gsla"), ".grd"), overwrite = TRUE)#, format = .output_format) 
-      writeRaster(out_brick$vcur, filename = paste0(file.path(path, "rs_vcur"), ".grd"), overwrite = TRUE)#, format = .output_format) 
-      writeRaster(out_brick$ucur, filename = paste0(file.path(path, "rs_ucur"), ".grd"), overwrite = TRUE)#, format = .output_format) 
+      writeRaster(out_brick$gsla, filename = paste0(file.path(path, "rs_gsla"), .output_format), overwrite = TRUE)
+      writeRaster(out_brick$vcur, filename = paste0(file.path(path, "rs_vcur"), .output_format), overwrite = TRUE)
+      writeRaster(out_brick$ucur, filename = paste0(file.path(path, "rs_ucur"), .output_format), overwrite = TRUE)
     } else {
       if(any(is.na(crs(out_brick)), is.null(crs(out_brick)))) {
         crs(out_brick) <- "epsg:4326"
       }
-      writeRaster(out_brick, filename = paste0(file.path(path, var_name), ".grd"), overwrite = TRUE) #, format = .output_format) 
+      writeRaster(out_brick, filename = paste0(file.path(path, var_name), .output_format), overwrite = TRUE)
     }
   } 
 

--- a/man/dot-pull_env.Rd
+++ b/man/dot-pull_env.Rd
@@ -12,7 +12,7 @@
   .cache,
   .crop,
   .nrt = FALSE,
-  .output_format = "raster",
+  .output_format = ".grd",
   .parallel = TRUE,
   .ncores = NULL,
   verbose = TRUE

--- a/man/extractEnv.Rd
+++ b/man/extractEnv.Rd
@@ -18,7 +18,7 @@ extractEnv(
   fill_gaps = FALSE,
   buffer = NULL,
   nrt = FALSE,
-  output_format = "raster",
+  output_format = ".grd",
   .parallel = TRUE,
   .ncores = NULL
 )

--- a/tests/testthat/test-extractEnv.R
+++ b/tests/testthat/test-extractEnv.R
@@ -19,10 +19,11 @@ test_that("extractEnv adds rs_current data", {
                          full_timeperiod = FALSE,
                          fill_gaps = TRUE,
                          folder_name = "test",
-                         .parallel = TRUE)
+                         .parallel = FALSE)
 
-  sub <- qc_data1[1, 56:60]
-  expect_named(sub, c("rs_gsla", 
+  sub <- qc_data1[1, 56:61]
+  expect_named(sub, c("date", 
+                      "rs_gsla", 
                       "rs_vcur", 
                       "rs_ucur", 
                       "rs_current_velocity", 


### PR DESCRIPTION
- Added additional URL verification check step at the end of .build_urls() to fix issue with missing IMOS data on servers.
- Fixed data extraction in .extract_var() caused by change over from `raster` to `terra`. Removal of extra pos_sf$layer column, and using date column to match extract matrix data to output dataset.
- Fixed gap filling feature that didnt work after change over to terra::extract. Inclusion of extra step in creating buffers using sf::st_buffer.
- Fixed writeRaster behaviour in pull_var() with change over to `terra`.
- Fixed .output_format behaviour in setting cached rasters in pull_var()
- Update parameter default in extractEnv() to change .output_format to '.grd'
- Prevent returned output dataset from removing date field
- Correct current bearing calculation in extractEnv()